### PR TITLE
meta: Add building-from-src.md

### DIFF
--- a/src/meta/topics/building-from-src.md
+++ b/src/meta/topics/building-from-src.md
@@ -1,0 +1,198 @@
+# Building from src
+
+## Unix / Macintosh
+
+Prerequisites:
+
+* `gcc` and `g++` 4.8 or newer, or
+* `clang` and `clang++` 3.4 or newer
+* Python 2.6 or 2.7
+* GNU Make 3.81 or newer
+* libexecinfo (FreeBSD and OpenBSD only)
+
+```text
+$ ./configure
+$ make
+$ [sudo] make install
+```
+
+If your Python binary is in a non-standard location or has a
+non-standard name, run the following instead:
+
+```text
+$ export PYTHON=/path/to/python
+$ $PYTHON ./configure
+$ make
+$ [sudo] make install
+```
+
+To run the tests:
+
+```text
+$ make test
+```
+
+To build the documentation:
+
+```text
+$ make doc
+```
+
+To read the documentation:
+
+```text
+$ man doc/iojs.1
+```
+
+## Windows
+
+Prerequisites:
+
+* [Python 2.6 or 2.7](https://www.python.org/downloads/)
+* Visual Studio 2013 for Windows Desktop, or
+* Visual Studio Express 2013 for Windows Desktop
+* Basic Unix tools required for some tests,
+  [Git for Windows](http://git-scm.com/download/win) includes Git Bash
+  and tools which can be included in the global `PATH`.
+
+```text
+> vcbuild nosign
+```
+
+To run the tests:
+
+```text
+> vcbuild test
+```
+
+## Android / Android based devices, aka. Firefox OS
+
+Be sure you have downloaded and extracted [Android NDK]
+(https://developer.android.com/tools/sdk/ndk/index.html)
+before in a folder. Then run:
+
+```
+$ ./android-configure /path/to/your/android-ndk
+$ make
+```
+
+## `Intl` (ECMA-402) support:
+
+[Intl](https://github.com/joyent/node/wiki/Intl) support is not
+enabled by default.
+
+### "small" (English only) support
+
+This option will build with "small" (English only) support, but
+the full `Intl` (ECMA-402) APIs.  With `--download=all` it will
+download the ICU library as needed.
+
+Unix / Macintosh:
+
+```text
+$ ./configure --with-intl=small-icu --download=all
+```
+
+Windows:
+
+```text
+> vcbuild small-icu download-all
+```
+
+The `small-icu` mode builds with English-only data. You can add full
+data at runtime.
+
+*Note:* more docs are on
+[the joyent/node wiki](https://github.com/joyent/node/wiki/Intl).
+
+### Build with full ICU support (all locales supported by ICU):
+
+With the `--download=all`, this may download ICU if you don't have an
+ICU in `deps/icu`.
+
+Unix / Macintosh:
+
+```text
+$ ./configure --with-intl=full-icu --download=all
+```
+
+Windows:
+
+```text
+> vcbuild full-icu download-all
+```
+
+### Build with no Intl support `:-(`
+
+The `Intl` object will not be available. This is the default at
+present, so this option is not normally needed.
+
+Unix / Macintosh:
+
+```text
+$ ./configure --with-intl=none
+```
+
+Windows:
+
+```text
+> vcbuild intl-none
+```
+
+### Use existing installed ICU (Unix / Macintosh only):
+
+```text
+$ pkg-config --modversion icu-i18n && ./configure --with-intl=system-icu
+```
+
+### Build with a specific ICU:
+
+You can find other ICU releases at
+[the ICU homepage](http://icu-project.org/download).
+Download the file named something like `icu4c-**##.#**-src.tgz` (or
+`.zip`).
+
+Unix / Macintosh
+
+```text
+# from an already-unpacked ICU:
+$ ./configure --with-intl=[small-icu,full-icu] --with-icu-source=/path/to/icu
+
+# from a local ICU tarball
+$ ./configure --with-intl=[small-icu,full-icu] --with-icu-source=/path/to/icu.tgz
+
+# from a tarball URL
+$ ./configure --with-intl=full-icu --with-icu-source=http://url/to/icu.tgz
+```
+
+Windows
+
+First unpack latest ICU to `deps/icu`
+[icu4c-**##.#**-src.tgz](http://icu-project.org/download) (or `.zip`)
+as `deps/icu` (You'll have: `deps/icu/source/...`)
+
+```text
+> vcbuild full-icu
+```
+
+### Building io.js with FIPS-compliant OpenSSL
+
+NOTE: Windows is not yet supported
+
+It is possible to build io.js with
+[OpenSSL FIPS module](https://www.openssl.org/docs/fips/fipsnotes.html).
+
+Instructions:
+
+1. Download and verify `openssl-fips-x.x.x.tar.gz` from
+   https://www.openssl.org/source/
+2. Extract source to `openssl-fips` folder
+3. ``cd openssl-fips && ./config fipscanisterbuild --prefix=`pwd`/out``
+   (NOTE: On OS X, you may want to run
+    ``./Configure darwin64-x86_64-cc --prefix=`pwd`/out`` if you are going to
+    build x64-mode io.js)
+4. `make -j && make install`
+5. Get into io.js checkout folder
+6. `./configure --openssl-fips=/path/to/openssl-fips/out`
+7. Build io.js with `make -j`
+8. Verify with `node -p "process.versions.openssl"` (`1.0.2a-fips`)


### PR DESCRIPTION
I lifted the instructions for building from source out of the readme in nodejs/io.js.

Do we want to point things in the meta section at stable node also? It seems to me like pointing contributors at io.js currently makes the most sense.

cc: @nodejs/documentation 
