### PR TITLE
fix title: 'Request' -> 'Transaction'

### DIFF
--- a/src/guides/anatomy-of-an-http-transaction.md
+++ b/src/guides/anatomy-of-an-http-transaction.md
@@ -1,4 +1,4 @@
-# Anatomy of an HTTP Request
+# Anatomy of an HTTP Transaction
 
 The purpose of this guide is to impart a solid understanding of the process of
 Node.js HTTP handling. We'll assume that you know, in a general sense, how HTTP


### PR DESCRIPTION
Somehow reviewers and I all missed this. The `h1`-level title in the doc should match the file name. Fixes that.
