### PR TITLE
Governance 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,9 @@ the documentation is.
 
 ## To **change** a document:
 
-1. *Fork* this repository to your account.
+1. *Fork* the appropriate repository to your account.
+  1. For API docs, that means <https://github.com/nodejs/node>.
+  2. For all other docs, that means <https://github.com/nodejs/nodejs.org>.
 2. *Clone* your fork.
 3. Make your changes locally.
 4. *Commit* your changes to a new branch.
@@ -52,10 +54,13 @@ the documentation is.
   are not "failed" PRs – they're valuable feedback, both for the submitter *and*
   the reviewer. Closed PRs help tell the project what it is just as much as
   merged PRs.
+  2. Your PR will also be subject to the contribution rules of the repository
+  you're making it on, so be mindful of them.
 
 ## To **write** a document:
 
-1. *Open* an issue describing the sort of document you'd like to write.
+1. *Open* an issue on this repository describing the sort of document you'd like
+to write.
   1. Include details about what audience you're addressing,
   2. what idea you'd like to convey to that audience,
   3. where you'll put the document,
@@ -66,7 +71,8 @@ the documentation is.
   *helpful*, go ahead and start working on it.
   2. If you're unsure, note your uncertainty in the issue, and wait for feedback
   to see whether the document is needed before starting work on it.
-3. To start work on your document, follow the [above process][] for **changing** a document.
+3. To start work on your document, follow the [above process][] for **changing** a
+document.
 
 ## To **join** the team:
 
@@ -80,6 +86,8 @@ Every month, new members will be added to the team. If you are added you will
 be paired with an existing editor from the team who will be responsible for
 your work for one month, upon successful completion of which you will become a
 full member.
+
+The description on membership or collaboratorship is in [GOVERNANCE.md][]
 
 ## To **review** a document:
 
@@ -128,14 +136,17 @@ Guidelines for commenting on work:
 
 ## To **merge** changes:
 
-Once a PR has a LGTM, any team member in full standing may merge it. Team
-members under mentorship may merge with the permission of their mentor.
+For this repository, once a PR has a LGTM, any team member in full standing may
+merge it. Team members under mentorship may merge with the permission of their
+mentor.
 
 Patches may be merged using the big green GitHub merge button if there are no
 conflicts.
 
 If there are conflicts, the PR should be updated to resolve any conflicts, and
 should be briefly re-reviewed before merging.
+
+For other repositories, their processes for merging apply.
 
 ## Developer's Certificate of Origin 1.0
 
@@ -213,3 +224,4 @@ CoC](http://www.rust-lang.org/conduct.html).
 [on this issue]: https://github.com/nodejs/docs/issues/2
 [nodejs/diversity working group]: https://github.com/nodejs/diversity
 [merge their changes]: #to-merge-changes
+[GOVERNANCE.md]: GOVERNANCE.md

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -64,21 +64,7 @@ necessarily have to be aimed at beginners.
 They are a great place for "deep dive" information, and to handle anything
 that's fairly intricate.
 3. **Reference** documents explain capabilities to help the reader achieve
-their goal.
-
-The larger structure of the project reflects this — there is a `guides`
-directory, a `topics` directory, and a `reference` directory.
-
-    // our directory structure:
-    src/
-      guides/
-      topics/
-      reference/
-    assets/
-      img/
-      css/
-      js/
-      code-examples/
+their goal. API documentation is the primary example of this.
 
 Every document we author should address **one primary audience** and describe
 **one complete idea**. If a document starts to address two audiences or ideas,

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,7 @@
-### Documentation Working Group
+# Documentation Working Group
 
-The Node.js Documentation group is jointly governed by a Working Group (WG) which is responsible for high-level guidance of the project.
+The Node.js Documentation group is jointly governed by a Working Group (WG)
+which is responsible for high-level guidance of the project.
 
 The WG has final authority over this project including:
 
@@ -11,56 +12,99 @@ The WG has final authority over this project including:
 * Conduct guidelines
 * Maintaining the list of additional Collaborators
 
-For the current list of WG members, see the project
-README.md.
+For the current list of WG members, see the project README.md.
 
-### Collaborators
+## Collaborators
 
-The Node.js Documenation WG GitHub repository is maintained by the WG and additional Collaborators who are added by the WG on an ongoing basis.
+The Node.js Documenation WG GitHub repository is maintained by the WG and
+additional Collaborators who are added by the WG on an ongoing basis.
 
-Individuals making significant and valuable contributions are made Collaborators and given commit-access to the project. These individuals are identified by the WG and their addition as Collaborators is discussed over GitHub issues - at time of writing, these individuals are encouraged to comment on [this speific issue](https://github.com/nodejs/docs/issues/2).
+Individuals making significant and valuable contributions are made Collaborators
+and given commit-access to the project. These individuals are identified by the
+WG and their addition as Collaborators is discussed over GitHub issues - at time
+of writing, these individuals are encouraged to comment on [this speific
+issue][].
 
-Modifications of the contents of the Node.js Documentation WG repository are made on a collaborative basis. Anybody with a GitHub account may propose a modification via pull request and it will be considered by the project Collaborators. All pull requests must be reviewed and accepted by a Collaborator with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing Collaborator, an additional Collaborator is required participate and there is disagreement around a particular modification. See _Consensus Seeking Process_ below for further detail on the consensus model used for governance.
+Modifications of the contents of the Node.js Documentation WG repository are
+made on a collaborative basis. Anybody with a GitHub account may propose a
+modification via pull request and it will be considered by the project
+Collaborators. All pull requests must be reviewed and accepted by a Collaborator
+with sufficient expertise who is able to take full responsibility for the
+change. In the case of pull requests proposed by an existing Collaborator, an
+additional Collaborator is required participate and there is disagreement around
+a particular modification. See _Consensus Seeking Process_ below for further
+detail on the consensus model used for governance.
 
-Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found consensus to the WG for discussion by assigning the `wg-agenda` tag to a pull request or issue. The WG should serve as the final arbiter where required.
+Collaborators may opt to elevate significant or controversial modifications, or
+modifications that have not found consensus to the WG for discussion by
+assigning the `wg-agenda` tag to a pull request or issue. The WG should serve as
+the final arbiter where required.
 
 For the current list of Collaborators, see the project `README.md`.
 
-### WG Membership
+## WG Membership
 
-WG seats are not time-limited.  There is no fixed size of the WG. However, the expected target is between 6 and 12, to ensure adequate coverage of important areas of expertise, balanced with the ability to make decisions efficiently.
+WG seats are not time-limited.  There is no fixed size of the WG. However, the
+expected target is between 6 and 12, to ensure adequate coverage of important
+areas of expertise, balanced with the ability to make decisions efficiently.
 
-There is no specific set of requirements or qualifications for WG membership beyond these rules.
+There is no specific set of requirements or qualifications for WG membership
+beyond these rules.
 
 The WG may add additional members to the WG by unanimous consensus.
 
-A WG member may be removed from the WG by voluntary resignation, or by unanimous consensus of all other WG members.
+A WG member may be removed from the WG by voluntary resignation, or by unanimous
+consensus of all other WG members.
 
-Changes to WG membership should be posted in the agenda, and may be suggested as any other agenda item (see "WG Meetings" below).
+Changes to WG membership should be posted in the agenda, and may be suggested as
+any other agenda item (see "WG Meetings" below).
 
-No more than 1/3 of the WG members may be affiliated with the same employer.  If removal or resignation of a WG member, or a change of employment by a WG member, creates a situation where more than 1/3 of the WG membership shares an employer, then the situation must be immediately remedied by the resignation or removal of one or more WG members affiliated with the over-represented employer(s).
+No more than 1/3 of the WG members may be affiliated with the same employer. If
+removal or resignation of a WG member, or a change of employment by a WG member,
+creates a situation where more than 1/3 of the WG membership shares an employer,
+then the situation must be immediately remedied by the resignation or removal of
+one or more WG members affiliated with the over-represented employer(s).
 
-### WG Agenda
+## WG Agenda
 
 <!-- this part needs to be rewritten. Will follow up with another commit that has those edits. -->
 
-Each week, an issue tagged `wg-weekly` will be created. It will be a sort of weekly digest on what's happened within the docs WG. The `wg-weekly` posts will contain links and descriptions to issues tagged with `wg-agenda`. The topics links are to be discussed within their respective `wg-agenda` tagged issues, **not** in the `wg-weekly` topics.
+Each week, an issue tagged `wg-weekly` will be created. It will be a sort of
+weekly digest on what's happened within the docs WG. The `wg-weekly` posts will
+contain links and descriptions to issues tagged with `wg-agenda`. The topics
+links are to be discussed within their respective `wg-agenda` tagged issues, **not*
+in the `wg-weekly` topics.
 
-Items are tagged with `wg-agenda` which are considered contentious or are modifications of governance, contribution policy, WG membership, or release process.
+Items are tagged with `wg-agenda` which are considered contentious or are
+modifications of governance, contribution policy, WG membership, or release
+process.
 
-The intention of the `wg-agenda` tag is not to seek approval or review all patches proposed - that should happen continuously on GitHub and be handled by the larger group of Collaborators.
+The intention of the `wg-agenda` tag is not to seek approval or review all
+patches proposed - that should happen continuously on GitHub and be handled by
+the larger group of Collaborators.
 
-Any community member or contributor can ask that issues be tagged with the `wg-agenda` tag by asking in the respective GitHub Issue. Any Collaborator, WG member or the moderator can add the item to the agenda by adding the `wg-agenda` tag to the issue themselves.
+Any community member or contributor can ask that issues be tagged with the
+`wg-agenda` tag by asking in the respective GitHub Issue. Any Collaborator, WG
+member or the moderator can add the item to the agenda by adding the `wg-agenda`
+tag to the issue themselves.
 
-The moderator is responsible for summarizing the discussion of each genda item and send it as a pull request after the meeting.
+The moderator is responsible for summarizing the discussion of each genda item
+and send it as a pull request after the meeting.
 
 ### Consensus Seeking Process
 
-The WG follows a [Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
-decision making model.
+The WG follows a [Consensus Seeking][] decision making model.
 
-When an agenda item has appeared to reach a consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
+When an agenda item has appeared to reach a consensus the moderator will ask
+"Does anyone object?" as a final call for dissent from the consensus.
 
-If an agenda item cannot reach a consensus a WG member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be seconded by a majority of the WG or else the discussion will continue. Simple majority wins.
+If an agenda item cannot reach a consensus a WG member can call for either a
+closing vote or a vote to table the issue to the next meeting. The call for a
+vote must be seconded by a majority of the WG or else the discussion will
+continue. Simple majority wins.
 
-Note that changes to WG membership require unanimous consensus.  See "WG Membership" above.
+Note that changes to WG membership require unanimous consensus.  See "WG
+Membership" above.
+
+[this speific issue]: https://github.com/nodejs/docs/issues/2
+[Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,12 +31,12 @@ modification via pull request and it will be considered by the project
 Collaborators. All pull requests must be reviewed and accepted by a Collaborator
 with sufficient expertise who is able to take full responsibility for the
 change. In the case of pull requests proposed by an existing Collaborator, an
-additional Collaborator is required participate and there is disagreement around
+additional Collaborator is required participate if there is disagreement around
 a particular modification. See _Consensus Seeking Process_ below for further
 detail on the consensus model used for governance.
 
 Collaborators may opt to elevate significant or controversial modifications, or
-modifications that have not found consensus to the WG for discussion by
+modifications that have not found consensus, to the WG for discussion by
 assigning the `wg-agenda` tag to a pull request or issue. The WG should serve as
 the final arbiter where required.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,7 +22,7 @@ additional Collaborators who are added by the WG on an ongoing basis.
 Individuals making significant and valuable contributions are made Collaborators
 and given commit-access to the project. These individuals are identified by the
 WG and their addition as Collaborators is discussed over GitHub issues - at time
-of writing, these individuals are encouraged to comment on [this speific
+of writing, these individuals are encouraged to comment on [this specific
 issue][].
 
 Modifications of the contents of the Node.js Documentation WG repository are
@@ -72,7 +72,7 @@ one or more WG members affiliated with the over-represented employer(s).
 Each week, an issue tagged `wg-weekly` will be created. It will be a sort of
 weekly digest on what's happened within the docs WG. The `wg-weekly` posts will
 contain links and descriptions to issues tagged with `wg-agenda`. The topics
-links are to be discussed within their respective `wg-agenda` tagged issues, **not*
+links are to be discussed within their respective `wg-agenda` tagged issues, **not**
 in the `wg-weekly` topics.
 
 Items are tagged with `wg-agenda` which are considered contentious or are
@@ -88,7 +88,7 @@ Any community member or contributor can ask that issues be tagged with the
 member or the moderator can add the item to the agenda by adding the `wg-agenda`
 tag to the issue themselves.
 
-The moderator is responsible for summarizing the discussion of each genda item
+The moderator is responsible for summarizing the discussion of each agenda item
 and send it as a pull request after the meeting.
 
 ### Consensus Seeking Process
@@ -106,5 +106,5 @@ continue. Simple majority wins.
 Note that changes to WG membership require unanimous consensus.  See "WG
 Membership" above.
 
-[this speific issue]: https://github.com/nodejs/docs/issues/2
+[this specific issue]: https://github.com/nodejs/docs/issues/2
 [Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,7 +1,6 @@
 ### Evangelism Working Group
 
-The Ndde.js Documentation group is jointly governed by a Working Group (WG)
-which is responsible for high-level guidance of the project.
+The Ndde.js Documentation group is jointly governed by a Working Group (WG) which is responsible for high-level guidance of the project.
 
 The WG has final authority over this project including:
 
@@ -17,107 +16,51 @@ README.md.
 
 ### Collaborators
 
-The Node.js Evangelism WG GitHub repository is
-maintained by the WG and additional Collaborators who are added by the
-WG on an ongoing basis.
+The Node.js Evangelism WG GitHub repository is maintained by the WG and additional Collaborators who are added by the WG on an ongoing basis.
 
-Individuals making significant and valuable contributions are made
-Collaborators and given commit-access to the project. These
-individuals are identified by the WG and their addition as
-Collaborators is discussed over GitHub issues - at time of writing, 
-these individuals are encouraged to comment on [this speific issue](https://github.com/nodejs/docs/issues/2).
+Individuals making significant and valuable contributions are made Collaborators and given commit-access to the project. These individuals are identified by the WG and their addition as Collaborators is discussed over GitHub issues - at time of writing, these individuals are encouraged to comment on [this speific issue](https://github.com/nodejs/docs/issues/2).
 
-Modifications of the contents of the Node.js Evangelism WG repository are made on
-a collaborative basis. Anybody with a GitHub account may propose a
-modification via pull request and it will be considered by the project
-Collaborators. All pull requests must be reviewed and accepted by a
-Collaborator with sufficient expertise who is able to take full
-responsibility for the change. In the case of pull requests proposed
-by an existing Collaborator, an additional Collaborator is required
-for sign-off. Consensus should be sought if additional Collaborators
-participate and there is disagreement around a particular
-modification. See _Consensus Seeking Process_ below for further detail
-on the consensus model used for governance.
+Modifications of the contents of the Node.js Evangelism WG repository are made on a collaborative basis. Anybody with a GitHub account may propose a modification via pull request and it will be considered by the project Collaborators. All pull requests must be reviewed and accepted by a Collaborator with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing Collaborator, an additional Collaborator is required participate and there is disagreement around a particular modification. See _Consensus Seeking Process_ below for further detail on the consensus model used for governance.
 
-Collaborators may opt to elevate significant or controversial
-modifications, or modifications that have not found consensus to the
-WG for discussion by assigning the ***WG-agenda*** tag to a pull
-request or issue. The WG should serve as the final arbiter where
-required.
+Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found consensus to the WG for discussion by assigning the ***WG-agenda*** tag to a pull request or issue. The WG should serve as the final arbiter where required.
 
 For the current list of Collaborators, see the project `README.md`.
 
 ### WG Membership
 
-WG seats are not time-limited.  There is no fixed size of the WG.
-However, the expected target is between 6 and 12, to ensure adequate
-coverage of important areas of expertise, balanced with the ability to
-make decisions efficiently.
+WG seats are not time-limited.  There is no fixed size of the WG. However, the expected target is between 6 and 12, to ensure adequate coverage of important areas of expertise, balanced with the ability to make decisions efficiently.
 
-There is no specific set of requirements or qualifications for WG
-membership beyond these rules.
+There is no specific set of requirements or qualifications for WG membership beyond these rules.
 
 The WG may add additional members to the WG by unanimous consensus.
 
-A WG member may be removed from the WG by voluntary resignation, or by
-unanimous consensus of all other WG members.
+A WG member may be removed from the WG by voluntary resignation, or by unanimous consensus of all other WG members.
 
-Changes to WG membership should be posted in the agenda, and may be
-suggested as any other agenda item (see "WG Meetings" below).
+Changes to WG membership should be posted in the agenda, and may be suggested as any other agenda item (see "WG Meetings" below).
 
-No more than 1/3 of the WG members may be affiliated with the same
-employer.  If removal or resignation of a WG member, or a change of
-employment by a WG member, creates a situation where more than 1/3 of
-the WG membership shares an employer, then the situation must be
-immediately remedied by the resignation or removal of one or more WG
-members affiliated with the over-represented employer(s).
+No more than 1/3 of the WG members may be affiliated with the same employer.  If removal or resignation of a WG member, or a change of employment by a WG member, creates a situation where more than 1/3 of the WG membership shares an employer, then the situation must be immediately remedied by the resignation or removal of one or more WG members affiliated with the over-represented employer(s).
 
-### WG Meetings
+### WG Agenda
 
 <!-- this part needs to be rewritten. Will follow up with another commit that has those edits. -->
 
-The WG meets weekly on a Google Hangout On Air. The meeting is run by
-a designated moderator approved by the WG. Each meeting should be
-published to YouTube.
+Each week, an issue tagged `wg-weekly` will be created. It will be a sort of weekly digest on what's happened within the docs WG. The `wg-weekly` posts will contain links and descriptions to issues tagged with `wg-agenda`. The topics links are to be discussed within their respective `wg-agenda` tagged issues, **not** in the `wg-weekly` topics.
 
-Items are added to the WG agenda which are considered contentious or
-are modifications of governance, contribution policy, WG membership,
-or release process.
+Items are tagged with `wg-agenda` which are considered contentious or are modifications of governance, contribution policy, WG membership, or release process.
 
-The intention of the agenda is not to approve or review all patches,
-that should happen continuously on GitHub and be handled by the larger
-group of Collaborators.
+The intention of the `wg-agenda` tag is not to seek approval or review all patches proposed - that should happen continuously on GitHub and be handled by the larger group of Collaborators.
 
-Any community member or contributor can ask that something be added to
-the next meeting's agenda by logging a GitHub Issue. Any Collaborator,
-WG member or the moderator can add the item to the agenda by adding
-the ***WG-agenda*** tag to the issue.
+Any community member or contributor can ask that issues be tagged with the `wg-agenda` tag by asking in the respective GitHub Issue. Any Collaborator, WG member or the moderator can add the item to the agenda by adding the `wg-agenda` tag to the issue themselves.
 
-Prior to each WG meeting the moderator will share the Agenda with
-members of the WG. WG members can add any items they like to the
-agenda at the beginning of each meeting. The moderator and the WG
-cannot veto or remove items.
-
-The WG may invite persons or representatives from certain projects to
-participate in a non-voting capacity.
-
-The moderator is responsible for summarizing the discussion of each
-agenda item and send it as a pull request after the meeting.
+The moderator is responsible for summarizing the discussion of each genda item and send it as a pull request after the meeting.
 
 ### Consensus Seeking Process
 
-The WG follows a
-[Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
+The WG follows a [Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
 decision making model.
 
-When an agenda item has appeared to reach a consensus the moderator
-will ask "Does anyone object?" as a final call for dissent from the
-consensus.
+When an agenda item has appeared to reach a consensus the moderator will ask "Does anyone object?" as a final call for dissent from the consensus.
 
-If an agenda item cannot reach a consensus a WG member can call for
-either a closing vote or a vote to table the issue to the next
-meeting. The call for a vote must be seconded by a majority of the WG
-or else the discussion will continue. Simple majority wins.
+If an agenda item cannot reach a consensus a WG member can call for either a closing vote or a vote to table the issue to the next meeting. The call for a vote must be seconded by a majority of the WG or else the discussion will continue. Simple majority wins.
 
-Note that changes to WG membership require unanimous consensus.  See
-"WG Membership" above.
+Note that changes to WG membership require unanimous consensus.  See "WG Membership" above.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,7 +22,7 @@ Individuals making significant and valuable contributions are made Collaborators
 
 Modifications of the contents of the Node.js Documentation WG repository are made on a collaborative basis. Anybody with a GitHub account may propose a modification via pull request and it will be considered by the project Collaborators. All pull requests must be reviewed and accepted by a Collaborator with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing Collaborator, an additional Collaborator is required participate and there is disagreement around a particular modification. See _Consensus Seeking Process_ below for further detail on the consensus model used for governance.
 
-Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found consensus to the WG for discussion by assigning the ***WG-agenda*** tag to a pull request or issue. The WG should serve as the final arbiter where required.
+Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found consensus to the WG for discussion by assigning the `wg-agenda` tag to a pull request or issue. The WG should serve as the final arbiter where required.
 
 For the current list of Collaborators, see the project `README.md`.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,123 @@
+### Evangelism Working Group
+
+The Ndde.js Documentation group is jointly governed by a Working Group (WG)
+which is responsible for high-level guidance of the project.
+
+The WG has final authority over this project including:
+
+* Technical direction
+* Project governance and process (including this policy)
+* Contribution policy
+* GitHub repository hosting
+* Conduct guidelines
+* Maintaining the list of additional Collaborators
+
+For the current list of WG members, see the project
+README.md.
+
+### Collaborators
+
+The Node.js Evangelism WG GitHub repository is
+maintained by the WG and additional Collaborators who are added by the
+WG on an ongoing basis.
+
+Individuals making significant and valuable contributions are made
+Collaborators and given commit-access to the project. These
+individuals are identified by the WG and their addition as
+Collaborators is discussed over GitHub issues - at time of writing, 
+these individuals are encouraged to comment on [this speific issue](https://github.com/nodejs/docs/issues/2).
+
+Modifications of the contents of the Node.js Evangelism WG repository are made on
+a collaborative basis. Anybody with a GitHub account may propose a
+modification via pull request and it will be considered by the project
+Collaborators. All pull requests must be reviewed and accepted by a
+Collaborator with sufficient expertise who is able to take full
+responsibility for the change. In the case of pull requests proposed
+by an existing Collaborator, an additional Collaborator is required
+for sign-off. Consensus should be sought if additional Collaborators
+participate and there is disagreement around a particular
+modification. See _Consensus Seeking Process_ below for further detail
+on the consensus model used for governance.
+
+Collaborators may opt to elevate significant or controversial
+modifications, or modifications that have not found consensus to the
+WG for discussion by assigning the ***WG-agenda*** tag to a pull
+request or issue. The WG should serve as the final arbiter where
+required.
+
+For the current list of Collaborators, see the project `README.md`.
+
+### WG Membership
+
+WG seats are not time-limited.  There is no fixed size of the WG.
+However, the expected target is between 6 and 12, to ensure adequate
+coverage of important areas of expertise, balanced with the ability to
+make decisions efficiently.
+
+There is no specific set of requirements or qualifications for WG
+membership beyond these rules.
+
+The WG may add additional members to the WG by unanimous consensus.
+
+A WG member may be removed from the WG by voluntary resignation, or by
+unanimous consensus of all other WG members.
+
+Changes to WG membership should be posted in the agenda, and may be
+suggested as any other agenda item (see "WG Meetings" below).
+
+No more than 1/3 of the WG members may be affiliated with the same
+employer.  If removal or resignation of a WG member, or a change of
+employment by a WG member, creates a situation where more than 1/3 of
+the WG membership shares an employer, then the situation must be
+immediately remedied by the resignation or removal of one or more WG
+members affiliated with the over-represented employer(s).
+
+### WG Meetings
+
+<!-- this part needs to be rewritten. Will follow up with another commit that has those edits. -->
+
+The WG meets weekly on a Google Hangout On Air. The meeting is run by
+a designated moderator approved by the WG. Each meeting should be
+published to YouTube.
+
+Items are added to the WG agenda which are considered contentious or
+are modifications of governance, contribution policy, WG membership,
+or release process.
+
+The intention of the agenda is not to approve or review all patches,
+that should happen continuously on GitHub and be handled by the larger
+group of Collaborators.
+
+Any community member or contributor can ask that something be added to
+the next meeting's agenda by logging a GitHub Issue. Any Collaborator,
+WG member or the moderator can add the item to the agenda by adding
+the ***WG-agenda*** tag to the issue.
+
+Prior to each WG meeting the moderator will share the Agenda with
+members of the WG. WG members can add any items they like to the
+agenda at the beginning of each meeting. The moderator and the WG
+cannot veto or remove items.
+
+The WG may invite persons or representatives from certain projects to
+participate in a non-voting capacity.
+
+The moderator is responsible for summarizing the discussion of each
+agenda item and send it as a pull request after the meeting.
+
+### Consensus Seeking Process
+
+The WG follows a
+[Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making)
+decision making model.
+
+When an agenda item has appeared to reach a consensus the moderator
+will ask "Does anyone object?" as a final call for dissent from the
+consensus.
+
+If an agenda item cannot reach a consensus a WG member can call for
+either a closing vote or a vote to table the issue to the next
+meeting. The call for a vote must be seconded by a majority of the WG
+or else the discussion will continue. Simple majority wins.
+
+Note that changes to WG membership require unanimous consensus.  See
+"WG Membership" above.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
-### Evangelism Working Group
+### Documentation Working Group
 
-The Ndde.js Documentation group is jointly governed by a Working Group (WG) which is responsible for high-level guidance of the project.
+The Node.js Documentation group is jointly governed by a Working Group (WG) which is responsible for high-level guidance of the project.
 
 The WG has final authority over this project including:
 
@@ -16,11 +16,11 @@ README.md.
 
 ### Collaborators
 
-The Node.js Evangelism WG GitHub repository is maintained by the WG and additional Collaborators who are added by the WG on an ongoing basis.
+The Node.js Documenation WG GitHub repository is maintained by the WG and additional Collaborators who are added by the WG on an ongoing basis.
 
 Individuals making significant and valuable contributions are made Collaborators and given commit-access to the project. These individuals are identified by the WG and their addition as Collaborators is discussed over GitHub issues - at time of writing, these individuals are encouraged to comment on [this speific issue](https://github.com/nodejs/docs/issues/2).
 
-Modifications of the contents of the Node.js Evangelism WG repository are made on a collaborative basis. Anybody with a GitHub account may propose a modification via pull request and it will be considered by the project Collaborators. All pull requests must be reviewed and accepted by a Collaborator with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing Collaborator, an additional Collaborator is required participate and there is disagreement around a particular modification. See _Consensus Seeking Process_ below for further detail on the consensus model used for governance.
+Modifications of the contents of the Node.js Documentation WG repository are made on a collaborative basis. Anybody with a GitHub account may propose a modification via pull request and it will be considered by the project Collaborators. All pull requests must be reviewed and accepted by a Collaborator with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing Collaborator, an additional Collaborator is required participate and there is disagreement around a particular modification. See _Consensus Seeking Process_ below for further detail on the consensus model used for governance.
 
 Collaborators may opt to elevate significant or controversial modifications, or modifications that have not found consensus to the WG for discussion by assigning the ***WG-agenda*** tag to a pull request or issue. The WG should serve as the final arbiter where required.
 


### PR DESCRIPTION
During the meeting we had, I had volunteered to take this on, so here it goes.

This builds on @bnb's earlier efforts. I've removed references to the directory structure in this repo, as all docs are in other repos. 

@chrisdickinson you had mentioned that some of the content was doubled between files. Since the files serve ever-so-slightly different purposes, I've left pretty much all of that intact, making some references between each other. I'm cool with changing that though.
