### PR TITLE
an initial README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # docs
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nodejs/docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+Hi there! This repo serves as a central place for Node.js documentation
+coordination, but not documentation itself. The documentation for node can be
+found at <http://nodejs.org/en/docs/>. The source material is found in both the
+[website repo][] and the [node core repo][].
+
+## Current Documentation WG Members
+
+* @bengl
+* @chrisdickinson
+* @danielkhan
+* @distracteddev
+* @drewfish
+* @Qard
+* @snostorm
+* @TheAlphaNerd
+
+[website repo]: https://github.com/nodejs/nodejs.org
+[node core repo]: https://github.com/nodejs/node


### PR DESCRIPTION
Add a little blurb about what the point of this repo is.

Add a list of WG members (using the @nodejs/documentation team members).

The list, in particular, is referenced in other docs, like
GOVERNANCE.md, so it should be here in the README.md.
