### PR TITLE
proposal: use hard wrapping for code and soft wrapping for prose

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -114,7 +114,7 @@ strategies are in service of that goal.
   * Filenames should be **lowercase**.
   * Older files may use the `.markdown` extension. These may be ported to `.md`
     at will. **Prefer `.md` for all new documents.**
-* Documents should be word-wrapped at 80 characters.
+* Code should be hard-wrapped at 80 characters, while prose should be soft-wrapped.
 * The formatting described in `.editorconfig` is preferred.
   * A [plugin][] is available for some editors to automatically apply these rules.
 * Mechanical issues, like spelling and grammar, should be identified by tools,


### PR DESCRIPTION
As a newcomer, I find hard wrapping prose to be extremely annoying and time consuming. I'm eager to hear counter arguments, but IMHO, it seems like a rule that just creates extra work for writers and reviewers.
