### PR TITLE
Update membership section of GOVERNANCE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,3 +222,4 @@ CoC](http://www.rust-lang.org/conduct.html).
 [nodejs/diversity working group]: https://github.com/nodejs/diversity
 [merge their changes]: #to-merge-changes
 [GOVERNANCE.md]: GOVERNANCE.md
+[docs-governance]: ./GOVERNANCE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,7 @@ the documentation is.
 ## To **change** a document:
 
 1. *Fork* the appropriate repository to your account.
-  1. For API docs, that means <https://github.com/nodejs/node>.
-  2. For all other docs, that means <https://github.com/nodejs/nodejs.org>.
+  1. This is usually <https://github.com/nodejs/node>.
 2. *Clone* your fork.
 3. Make your changes locally.
 4. *Commit* your changes to a new branch.
@@ -82,10 +81,8 @@ as part of the team, you are expected to be an *exemplar* of the project's
 values – both in making this specific project a welcoming place to contribute,
 as well as in the larger community (other issue trackers, conferences, etc.)
 
-Every month, new members will be added to the team. If you are added you will
-be paired with an existing editor from the team who will be responsible for
-your work for one month, upon successful completion of which you will become a
-full member.
+The full details of membership access and responsibilities are listed in
+[the `GOVERNANCE.md` file][docs-governance].
 
 The description on membership or collaboratorship is in [GOVERNANCE.md][]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,6 @@ as well as in the larger community (other issue trackers, conferences, etc.)
 The full details of membership access and responsibilities are listed in
 [the `GOVERNANCE.md` file][docs-governance].
 
-The description on membership or collaboratorship is in [GOVERNANCE.md][]
-
 ## To **review** a document:
 
 1. If a PR already has an assigned team member, post a comment on the PR asking

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,49 +12,98 @@ The WG has final authority over this project including:
 * Conduct guidelines
 * Maintaining the list of additional Collaborators
 
-For the current list of WG members, see the project README.md.
+For the current list of WG members, see [the project README.md][nodejs-docs-].
 
-## Collaborators
+## Membership
 
-The Node.js Documenation WG GitHub repository is maintained by the WG and
-additional Collaborators who are added by the WG on an ongoing basis.
+### Joining the WG
 
-Individuals making significant and valuable contributions are made Collaborators
-and given commit-access to the project. These individuals are identified by the
-WG and their addition as Collaborators is discussed over GitHub issues - at time
-of writing, these individuals are encouraged to comment on [this specific
-issue][].
+Membership may be extended by current WG members to individuals who have made
+contributions to documentation in the Node or JavaScript communities who **have
+expressed interest in membership**. Candidates for membership will be approved
+or denied by existing WG members use the [Consensus Seeking Process][consensus]
+process below. Individuals may express interest publicly on the [sign-up
+issue][sign-up] or privately to any existing Docs WG member. Put simply: **if
+you are a documentarian and are willing to fulfill the [responsibilities of
+membership][membership-responsibilities] to the best of your ability, the Docs
+WG would be happy to receive your help.**
+
+The Docs WG encourages prospective members to read the
+[CONTRIBUTING.md][nodejs-doc-contributing] and
+[GETTING-STARTED.md][nodejs-doc-getting-started] documents for an idea of how
+the WG operates.
+
+### Membership Access and Responsibilities
+
+Membership in the Node.js Documentation WG entails the following access:
+
+* Membership in the [Node.js Documentation Slack][nodejs-doc-slack].
+* Membership in the **@nodejs/documentation** GitHub team.
+* Collaboratorship on the [Node.js Documentation Repository][nodejs-doc-repo].
+
+Members should prepare to take part in the following activities, to the best of
+their abilities:
+
+* Attend meetings in the form of Google Hangouts.
+* Coordinate via [**nodejs/docs** issues][nodejs-doc-repo].
+* Coordinate with WG members via [Slack][nodejs-doc-slack].
+* Respond to pull requests, and issues on the **nodejs/node** tracker that:
+  * are tagged with the `doc` label, OR
+  * have cc'd **@nodejs/documentation**, OR
+  * modify the `doc/` or `tools/docs` directory.
+* Apply the [editing standards][nodejs-doc-standards] recommended by the WG to
+  all documentation review.
+* Keep the [goals][nodejs-doc-goals] set by the WG in mind when contributing
+  documentation.
+
+**The WG recognizes that this is largely a volunteer effort, and will endeavour
+to adjust the time commitment of participation in the WG to reflect that.** If
+you would like to contribute, but cannot participate in one or more of the
+above tasks, please contact a WG member. The WG will attempt to make
+accomodations for interested individuals.
+
+Members are expected to conduct themselves according to the [Docs WG Code of
+Conduct][nodejs-doc-coc] as well as any Code of Conduct set by the larger Node
+Foundation. The Code of Conduct is enforced by the [Moderation
+WG][nodejs-moderation]. Any Docs WG banned from the Node project by the
+Moderation WG will also be removed from the Docs WG. To report a violation of
+the Code of Conduct, please [follow the steps listed
+here][nodejs-moderation-request].
+
+### Membership Collaboration
+
+#### Documentation Review and Copyediting
+
+Follow the process outlined in [CONTRIBUTING.md][nodejs-doc-contributing].
+
+#### Changes to Docs WG Guidelines and Process
 
 Modifications of the contents of the Node.js Documentation WG repository are
 made on a collaborative basis. Anybody with a GitHub account may propose a
 modification via pull request and it will be considered by the project
-Collaborators. All pull requests must be reviewed and accepted by a Collaborator
-with sufficient expertise who is able to take full responsibility for the
-change. In the case of pull requests proposed by an existing Collaborator, an
-additional Collaborator is required participate if there is disagreement around
-a particular modification. See _Consensus Seeking Process_ below for further
-detail on the consensus model used for governance.
+Collaborators. All pull requests must be reviewed and accepted by a
+Collaborator with sufficient expertise who is able to take full responsibility
+for the change. In the case of pull requests proposed by an existing
+Collaborator, an additional Collaborator is required participate if there is
+disagreement around a particular modification. [See _Consensus Seeking Process_
+below][consensus] for further detail on the consensus model used for
+governance.
 
 Collaborators may opt to elevate significant or controversial modifications, or
 modifications that have not found consensus, to the WG for discussion by
 assigning the `wg-agenda` tag to a pull request or issue. The WG should serve as
 the final arbiter where required.
 
-For the current list of Collaborators, see the project `README.md`.
+#### Additional Membership Constraints
 
-## WG Membership
-
-WG seats are not time-limited.  There is no fixed size of the WG. However, the
-expected target is between 6 and 12, to ensure adequate coverage of important
-areas of expertise, balanced with the ability to make decisions efficiently.
-
-There is no specific set of requirements or qualifications for WG membership
-beyond these rules.
+WG seats are not time-limited. There is no fixed size of the WG. There is no
+specific set of requirements or qualifications for WG membership beyond rules
+set forth in this document.
 
 The WG may add additional members to the WG by unanimous consensus.
 
-A WG member may be removed from the WG by voluntary resignation, or by unanimous
-consensus of all other WG members.
+A WG member may be removed from the WG by voluntary resignation, by unanimous
+consensus of all other WG members, or by ruling from the Node.js Moderation WG.
 
 Changes to WG membership should be posted in the agenda, and may be suggested as
 any other agenda item (see "WG Meetings" below).
@@ -65,15 +114,7 @@ creates a situation where more than 1/3 of the WG membership shares an employer,
 then the situation must be immediately remedied by the resignation or removal of
 one or more WG members affiliated with the over-represented employer(s).
 
-## WG Agenda
-
-<!-- this part needs to be rewritten. Will follow up with another commit that has those edits. -->
-
-Each week, an issue tagged `wg-weekly` will be created. It will be a sort of
-weekly digest on what's happened within the docs WG. The `wg-weekly` posts will
-contain links and descriptions to issues tagged with `wg-agenda`. The topics
-links are to be discussed within their respective `wg-agenda` tagged issues, **not**
-in the `wg-weekly` topics.
+#### WG Meeting Agenda
 
 Items are tagged with `wg-agenda` which are considered contentious or are
 modifications of governance, contribution policy, WG membership, or release
@@ -91,9 +132,11 @@ tag to the issue themselves.
 The moderator is responsible for summarizing the discussion of each agenda item
 and send it as a pull request after the meeting.
 
-### Consensus Seeking Process
+A regular cadence will be determined for meetings by consent of the WG.
 
-The WG follows a [Consensus Seeking][] decision making model.
+#### Consensus Seeking Process
+
+The WG follows a [Consensus Seeking][external-consensus] decision making model.
 
 When an agenda item has appeared to reach a consensus the moderator will ask
 "Does anyone object?" as a final call for dissent from the consensus.
@@ -106,5 +149,16 @@ continue. Simple majority wins.
 Note that changes to WG membership require unanimous consensus.  See "WG
 Membership" above.
 
-[this specific issue]: https://github.com/nodejs/docs/issues/2
-[Consensus Seeking]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making
+[consensus]: #consensus-seeking-process
+[sign-up]: https://github.com/nodejs/docs/issues/2
+[membership-responsibilities]: #membership-access-and-responsibilities
+[nodejs-doc-slack]: https://nodejs-docs.slack.com/
+[nodejs-doc-repo]: https://github.com/nodejs/docs
+[nodejs-doc-standards]: https://github.com/nodejs/docs/blob/master/GETTING-STARTED.md#how-we-write
+[nodejs-doc-goals]: https://github.com/nodejs/docs/blob/master/GETTING-STARTED.md#why-we-write-docs
+[nodejs-doc-coc]: https://github.com/nodejs/docs/blob/master/CONTRIBUTING.md#code-of-conduct
+[nodejs-moderation]: https://github.com/nodejs/moderation
+[nodejs-moderation-request]: https://github.com/nodejs/TSC/blob/master/Moderation-Policy.md#requesting-moderation
+[nodejs-doc-contributing]: ./CONTRIBUTING.md
+[nodejs-doc-getting-started]: ./GETTING-STARTED.md
+[external-consensus]: http://en.wikipedia.org/wiki/Consensus-seeking_decision-making

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,12 +21,12 @@ For the current list of WG members, see [the project README.md][nodejs-docs-].
 Membership may be extended by current WG members to individuals who have made
 contributions to documentation in the Node or JavaScript communities who **have
 expressed interest in membership**. Candidates for membership will be approved
-or denied by existing WG members use the [Consensus Seeking Process][consensus]
-process below. Individuals may express interest publicly on the [sign-up
-issue][sign-up] or privately to any existing Docs WG member. Put simply: **if
-you are a documentarian and are willing to fulfill the [responsibilities of
-membership][membership-responsibilities] to the best of your ability, the Docs
-WG would be happy to receive your help.**
+or denied by existing WG members using the [Consensus Seeking
+Process][consensus] process below. Individuals may express interest publicly on
+the [sign-up issue][sign-up] or privately to any existing Docs WG member. Put
+simply: **if you are a documentarian and are willing to fulfill the
+[responsibilities of membership][membership-responsibilities] to the best of
+your ability, the Docs WG would be happy to receive your help.**
 
 The Docs WG encourages prospective members to read the
 [CONTRIBUTING.md][nodejs-doc-contributing] and
@@ -60,7 +60,8 @@ their abilities:
 to adjust the time commitment of participation in the WG to reflect that.** If
 you would like to contribute, but cannot participate in one or more of the
 above tasks, please contact a WG member. The WG will attempt to make
-accomodations for interested individuals.
+accomodations for interested individuals. *Members are not required to be
+collaborators on the `nodejs/node` repository.*
 
 Members are expected to conduct themselves according to the [Docs WG Code of
 Conduct][nodejs-doc-coc] as well as any Code of Conduct set by the larger Node

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # docs
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nodejs/docs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 Hi there! This repo serves as a central place for Node.js documentation
 coordination, but not documentation itself. The documentation for node can be
-found at <http://nodejs.org/en/docs/>. The source material is found in both the
-[website repo][] and the [node core repo][].
+found at <http://nodejs.org/en/docs/>. The source material is found in the
+[node core repo][].
 
 ## Current Documentation WG Members
 
@@ -18,5 +16,4 @@ found at <http://nodejs.org/en/docs/>. The source material is found in both the
 * @snostorm
 * @TheAlphaNerd
 
-[website repo]: https://github.com/nodejs/nodejs.org
 [node core repo]: https://github.com/nodejs/node


### PR DESCRIPTION
While running through the responses to the call for membership, I realized that the existing GOVERNANCE document was a bit lax on details for membership. Specifically, it did not answer:
- Who should be members?
- What are members expected to do?
- How should individuals go about becoming a member?
- Under what circumstances does a member leave the WG?

In addition, the CONTRIBUTING doc was a bit off from where we're at right now: it's expected, at least in the near term future, that we'll be operating primarily in the nodejs/node repo.

This PR attempts to address the questions above and is meant as jumping off point for discussion! I'm going to cc the folks who have publicly raised their hand to help out on this issue too, to make sure they're OK with all of this. In addition, I will reach out privately to all Node collaborators who have touched the docs in the last 6 months who are not part of the Docs WG.

This does not address _process_, _goal-setting_, or _tooling_, but that should follow in subsequent PRs to be discussed by the WG and CTC.

/cc @nodejs/documentation 
/cc @mikeal — could you make sure this looks okay w/r/t WG setup?
/cc @rvagg — You've expressed interest in the operation of the Docs WG in other issues, and I'd love your thoughts on this.
/cc @kosamari, @a0viedo — you've [both raised your hands to help out](https://github.com/nodejs/node/issues/4573) (thank you!), are there any questions you have that the membership section doesn't answer? Are the responsibilities and access outlined here in line with what you'd expect, or is it too much?
