### PR TITLE
Add links to member list

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,29 @@ found at <http://nodejs.org/en/docs/>. The source material is found in the
 
 ## Current Documentation WG Members
 
-* @a0viedo
-* @ashleygwilliams
-* @bengl
-* @chrisdickinson
-* @danielkhan
-* @danjenkins
-* @DavidTPate
-* @distracteddev
-* @drewfish
-* @eljefedelrodeodeljefe
-* @kahwee
-* @kelthenoble
-* @kosamari
-* @Qard
-* @rodmachen
-* @romankl
-* @rubo-21
-* @ryansobol
-* @snostorm
-* @stevemao
-* @techjeffharris
-* @TheAlphaNerd
-* @thefourtheye
-* @tomgco
+* [**@a0viedo**](https://github.com/a0viedo)
+* [**@ashleygwilliams**](https://github.com/ashleygwilliams)
+* [**@bengl**](https://github.com/bengl)
+* [**@chrisdickinson**](https://github.com/chrisdickinson)
+* [**@danielkhan**](https://github.com/danielkhan)
+* [**@danjenkins**](https://github.com/danjenkins)
+* [**@DavidTPate**](https://github.com/DavidTPate)
+* [**@distracteddev**](https://github.com/distracteddev)
+* [**@drewfish**](https://github.com/drewfish)
+* [**@eljefedelrodeodeljefe**](https://github.com/eljefedelrodeodeljefe)
+* [**@kahwee**](https://github.com/kahwee)
+* [**@kelthenoble**](https://github.com/kelthenoble)
+* [**@kosamari**](https://github.com/kosamari)
+* [**@Qard**](https://github.com/Qard)
+* [**@rodmachen**](https://github.com/rodmachen)
+* [**@romankl**](https://github.com/romankl)
+* [**@rubo-21**](https://github.com/rubo-21)
+* [**@ryansobol**](https://github.com/ryansobol)
+* [**@snostorm**](https://github.com/snostorm)
+* [**@stevemao**](https://github.com/stevemao)
+* [**@techjeffharris**](https://github.com/techjeffharris)
+* [**@TheAlphaNerd**](https://github.com/TheAlphaNerd)
+* [**@thefourtheye**](https://github.com/thefourtheye)
+* [**@tomgco**](https://github.com/tomgco)
 
 [node core repo]: https://github.com/nodejs/node


### PR DESCRIPTION
I noticed that the member list did not actually link to profile pages. I’m not sure whether that was intended or not, but I like links :)

P.S. I added strong-emphasis around the at-mentions because that’s more in line with how GitHub renders them (e.g., @wooorm, @mention)
